### PR TITLE
[nit] Fix Discord URL in sidebar

### DIFF
--- a/src/main.twee
+++ b/src/main.twee
@@ -8,7 +8,7 @@ brought to you by Kawa#7680
 
 
 :: StorySubtitle {"position":"392,432","size":"100,100"}
-If this tool doesn't help, or your needs are more specific, feel free to join us at https://discord.sibr.dev, specifically the "Help Desk" channel, and we can get you where you need to go.
+If this tool doesn't help, or your needs are more specific, feel free to join us at [[discord.sibr.dev|https://discord.sibr.dev]], specifically the "Help Desk" channel, and we can get you where you need to go.
 
 :: StoryMenu
 /* <<link "Toggle light/dark mode">>


### PR DESCRIPTION
The current form is accidentally including the comma in the URL, which is breaking it.